### PR TITLE
25 Fix The 'name' value must be set in other

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -190,11 +190,6 @@ function plagiarism_pchkorg_coursemodule_standard_elements($formwrapper, $mform)
     }
 }
 
-function plagiarism_pchkorg_coursemodule_edit_post_actions($data, $course)
-{
-
-}
-
 /**
  * Class plagiarism_plugin_pchkorg
  */


### PR DESCRIPTION
Remove empty function definition to resolve error "The 'name' value must be set in other" in Moodle 4.0.2 and higher.