### PR TITLE
27 Fix The 'name' value must be set in other

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -198,7 +198,7 @@ function plagiarism_pchkorg_coursemodule_edit_post_actions($data, $course)
 
     $config = $pchkorgconfigmodel->get_system_config('pchkorg_use');
     if ('1' != $config) {
-        return;
+        return $data;
     }
 
     $fields = array(


### PR DESCRIPTION
With this plugin's "Enable plugin" setting set to No, editing an activity's settings resulted in the error "Coding error detected, it must
be fixed by a programmer: The 'name' value must be set in other.".