### PR TITLE
Update lib.php "Support student custom roles"

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -329,7 +329,8 @@ class plagiarism_plugin_pchkorg extends plagiarism_plugin {
             $roles[] = strtolower($rolesData->shortname);
         }
         // Moodle has multiple roles in courses.
-        $isstudent = !in_array('teacher', $roles)
+        $isstudent = in_array('student', $roles)
+            && !in_array('teacher', $roles)
             && !in_array('editingteacher', $roles)
             && !in_array('managerteacher', $roles);
 
@@ -742,10 +743,9 @@ display: inline-block;"
                     $roles[] = strtolower($rolesData->shortname);
                 }
                 // Moodle has multiple roles in courses.
-                $isstudent = in_array('student', $roles)
-                    && !in_array('teacher', $roles)
-                    && !in_array('editingteacher', $roles)
-                    && !in_array('managerteacher', $roles);
+                $isstudent = !in_array('teacher', $roles)
+					&& !in_array('editingteacher', $roles)
+					&& !in_array('managerteacher', $roles);
                 $isregistered = $apiprovider->auto_registrate_member($name, $USER->email, $isstudent ? 3 : 2);
                 if (!$isregistered) {
                     return true;

--- a/lib.php
+++ b/lib.php
@@ -744,8 +744,8 @@ display: inline-block;"
                 }
                 // Moodle has multiple roles in courses.
                 $isstudent = !in_array('teacher', $roles)
-					&& !in_array('editingteacher', $roles)
-					&& !in_array('managerteacher', $roles);
+                    && !in_array('editingteacher', $roles)
+                    && !in_array('managerteacher', $roles);
                 $isregistered = $apiprovider->auto_registrate_member($name, $USER->email, $isstudent ? 3 : 2);
                 if (!$isregistered) {
                     return true;


### PR DESCRIPTION
8862dc0 introduced a bug that caused the widget to be disabled for an excess of Moodle user roles when the Plugin is set to _No_ for _Students can see a similarity score_, as users became considered "Students" as per `$isstudent` even if they were not students.

This change I believe was intentional, but to be applied where $isstudent is reassigned for the purpose of `$role` in `auto_registrate_member($name, $email, $role)`

I believe that this would have had the intended effect of avoiding real world students that don't have the specific named role 'student' on Moodle (i.e. having a custom role that uses the 'student' archetype but a different role name) from being given 'Teacher' role and permissions on plagiarismcheck.org